### PR TITLE
Volume was without limitation

### DIFF
--- a/commands/music/volume.js
+++ b/commands/music/volume.js
@@ -29,6 +29,12 @@ module.exports = {
                 await errorHandler({interaction: interaction, errorType: 'voiceChannelRequired', commandName: module.exports.name});
                 return;
             }
+            if(volume < 0 || volume > 150) {
+                return interaction.reply({
+                    content: ':x: The maximum volume increase is 150 and the minimum is 0'
+                })
+            }
+            
             const player = await polaris.moon.players.get(interaction.guild.id)
             await player.setVolume(volume);
 


### PR DESCRIPTION
If there was no limitation, the user could increase it to infinity, making very bad audio, and if it goes below 0, an error would occur in the moonlink.js package.